### PR TITLE
test protuAU with w/o AU

### DIFF
--- a/base/graph_recommender.py
+++ b/base/graph_recommender.py
@@ -7,7 +7,7 @@ from data.loader import FileIO
 from os.path import abspath
 from util.evaluation import ranking_evaluation
 import sys
-from picture.feature import plot_features
+from visualize.feature import plot_features
 import wandb
 
 

--- a/conf/ProtoAU.yaml
+++ b/conf/ProtoAU.yaml
@@ -1,11 +1,10 @@
 yelp2018:
-  name: SwAVGCL
+  name: ProtoAU
   seed: 12345
   type: graph
   ranking: 
     - 10
     - 20
-    - 50
   embedding_size: 64
   num_epochs: 120
   batch_size: 2048

--- a/index.py
+++ b/index.py
@@ -38,12 +38,14 @@ class Runner(object):
             self.config['type']
         )
 
+import os
+dir = os.path.abspath(os.path.dirname(__file__))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--model', type=str, default='ProtoAU')
-    parser.add_argument('--dataset', type=str, default='Yelp')
-    parser.add_argument('--root', type=str, default='/workspace/')
+    parser.add_argument('--dataset', type=str, default='yelp2018')
+    parser.add_argument('--root', type=str, default=f'{dir}')
     parser.add_argument('--gpu_id', type=int, default=0)
     parser.add_argument('--tags', nargs='*', default=[]) 
     parser.add_argument('--group', type=str, default='default')  #

--- a/model/graph/ProtoAU.py
+++ b/model/graph/ProtoAU.py
@@ -5,7 +5,7 @@ from base.graph_recommender import GraphRecommender
 from util.sampler import next_batch_pairwise
 from util.loss_torch import bpr_loss, l2_reg_loss
 import wandb
-from LightGCN import LGCN_Encoder
+from .LightGCN import LGCN_Encoder
 
 class ProtoAU(GraphRecommender):
     def __init__(self, conf, training_set, test_set):
@@ -37,10 +37,10 @@ class ProtoAU(GraphRecommender):
         cl_loss = user_loss + item_loss
         return self.config['model_config.proto_reg'] * cl_loss
 
-    def align_loss(x, y, alpha=2):
+    def align_loss(self , x, y, alpha=2):
         return (x - y).norm(p=2, dim=1).pow(alpha).mean()
 
-    def uniform_loss(x, t=2):
+    def uniform_loss(self , x, t=2):
         return torch.pdist(x, p=2).pow(2).mul(-t).exp().mean().log()
 
     def proto_loss(self, z, prototypes, temperature=0.1):
@@ -53,7 +53,7 @@ class ProtoAU(GraphRecommender):
 
         c_t = prototypes[score_t.max(dim=1)[1]]
         c_s = prototypes[score_s.max(dim=1)[1]]
-        loss_au = self.align_loss(c_s, c_t) + self.uniform_loss() # here we choose lambda_3=1
+        loss_au = 0. # self.align_loss(c_s, c_t) + self.uniform_loss(c_s - c_t) # here we choose lambda_3=1
 
         # Apply the Sinkhorn-Knopp algorithm to get soft cluster assignments
         q_t = self.sinkhorn_knopp(score_t)


### PR DESCRIPTION
want to test ProtoAU without alignment and uniformity objectives (referred to as ProtoAUw/o-AU)
but in dataset yelp2018 , the recall@20 only to 0.06 , the all Hyper-parameter not be modified

> wandb: Run summary:
wandb:      Hit Ratio@10 0.03072
wandb:      Hit Ratio@20 0.05356
wandb:           NDCG@10 0.04071
wandb:           NDCG@20 0.05015
wandb:      Precision@10 0.03144
wandb:      Precision@20 0.02741
wandb:         Recall@10 0.0349
wandb:         Recall@20 0.06008
wandb:        batch_loss 0.09954
wandb: best.Hit Ratio@10 0.03072
wandb: best.Hit Ratio@20 0.05356
wandb:      best.NDCG@10 0.04071
wandb:      best.NDCG@20 0.05015
wandb: best.Precision@10 0.03144
wandb: best.Precision@20 0.02741
wandb:    best.Recall@10 0.0349
wandb:    best.Recall@20 0.06008
wandb:           cl_loss 0.00187
wandb:             epoch 120
wandb:          rec_loss 0.09767